### PR TITLE
chore: cleanup old data

### DIFF
--- a/20230504_drop_old_data/main.go
+++ b/20230504_drop_old_data/main.go
@@ -1,0 +1,41 @@
+package models
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func Migrate() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20230504",
+		Migrate: func(tx *gorm.DB) error {
+			// drop all tables
+			if err := tx.Exec("truncate table deposit").Error; err != nil {
+				return err
+			}
+			if err := tx.Exec("truncate table event").Error; err != nil {
+				return err
+			}
+			if err := tx.Exec("truncate table job").Error; err != nil {
+				return err
+			}
+			if err := tx.Exec("truncate table processed_block").Error; err != nil {
+				return err
+			}
+			if err := tx.Exec("truncate table processed_receipt").Error; err != nil {
+				return err
+			}
+			if err := tx.Exec("truncate table task").Error; err != nil {
+				return err
+			}
+			if err := tx.Exec("truncate table withdrawal").Error; err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,17 @@
 package migration
 
 import (
+	"strings"
+
 	bridgeCore "github.com/axieinfinity/bridge-core"
 	models20220515 "github.com/axieinfinity/bridge-migrations/20220515_init"
 	models20220701 "github.com/axieinfinity/bridge-migrations/20220701_retry_all_failed_tx"
 	models20220703 "github.com/axieinfinity/bridge-migrations/20220703_add_timestamp_when_submit_tx"
 	models20220707 "github.com/axieinfinity/bridge-migrations/20220707_add_processed_receipt_table"
 	models20220708 "github.com/axieinfinity/bridge-migrations/20220708_update_processed_block"
+	models20230504 "github.com/axieinfinity/bridge-migrations/20230504_drop_old_data"
 	"github.com/go-gormigrate/gormigrate/v2"
 	"gorm.io/gorm"
-	"strings"
 )
 
 func Migrate(db *gorm.DB, cfg *bridgeCore.Config) error {
@@ -19,6 +21,7 @@ func Migrate(db *gorm.DB, cfg *bridgeCore.Config) error {
 		models20220703.Migrate(),
 		models20220707.Migrate(),
 		models20220708.Migrate(),
+		models20230504.Migrate(),
 	}
 	migrate := gormigrate.New(db, gormigrate.DefaultOptions, migrations)
 	for _, version := range migrations {


### PR DESCRIPTION
As new code is not backward compatible with old data, we cleanup old data and re-run the tracker from recent blocks.